### PR TITLE
Fix: 빌드 시 자바스크립트 heap memory 리밋 걸리는 문제 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4521,9 +4521,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -9915,6 +9915,13 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
       }
     },
     "react-side-effect": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@toast-ui/react-editor": "^3.1.2",
     "axios": "^0.24.0",
     "bootstrap": "^5.1.3",
+    "dotenv": "^16.0.0",
     "gh-pages": "^3.2.3",
     "html5-file-selector": "^2.1.0",
     "jwt-decode": "^3.1.2",
@@ -41,7 +42,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "node --max_old_space_size=4096 node_modules/.bin/react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",


### PR DESCRIPTION
## PR Category

> PR 종류를 선택해주세요.

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor Code
- [ ] Etc

## Linked Issues

> `#이슈번호` 형태로 추가해주세요.

- issue 1

## PR Summary

> 변경 사항을 요약해주세요. <br>
> (why -> what -> how)

- 빌드 시 heap 메모리 한계로 인해 배포가 불가했습니다. 
- 메모리를 더 할당하는 방식으로 문제 해결했습니다.

## Comment

> 추가로 논의할 내용이 있다면 적어주세요.

- 추후 어디서 메모리 누수가 일어나고 있는가 확인하고 이를 막는 것이 근본적인 문제 해결 방안일 것 같습니다.

## References

> 참고한 사이트가 있다면 공유해주세요.

- 노드 js 메모리 누수 (https://ajh322.tistory.com/243)
- 메모리 할당을 위한 react-script 변경 (https://lahuman.github.io/react_build_heap_momory/)

## Check List

- [x] 추가한 기능에 대한 테스트는 모두 완료했나요?
- [x] 코드 정렬, 불필요한 코드나 오타는 없는지 확인했나요?
